### PR TITLE
expose uptimeInterval for reporting purposes

### DIFF
--- a/Sources/TrueTime.swift
+++ b/Sources/TrueTime.swift
@@ -21,6 +21,7 @@ import Result
 
 @objc(NTPReferenceTime)
 public final class ReferenceTime: NSObject, ReferenceTimeContainer {
+    public var uptimeInterval: NSTimeInterval { return underlyingValue.uptimeInterval }
     public var time: NSDate { return underlyingValue.time }
     public var uptime: timeval { return underlyingValue.uptime }
     public func now() -> NSDate { return underlyingValue.now() }


### PR DESCRIPTION
For my app I'm wanting to expose the last time TrueTime was able to successfully poll the NTP server. This exposes that data. A follow up PR will make this against master for swift 3