### PR TITLE
fix(Compiler): performance improvements

### DIFF
--- a/Sources/NTPResponse.swift
+++ b/Sources/NTPResponse.swift
@@ -40,14 +40,11 @@ struct NTPResponse {
 }
 
 func bestTime(fromResponses times: [[FrozenNetworkTime]]) -> FrozenNetworkTime? {
-  let bestTimes = times
-    .map { serverTimes -> FrozenNetworkTime? in
+  let bestTimes = times.map { serverTimes -> FrozenNetworkTime? in
       return serverTimes.min { $0.serverResponse.delay < $1.serverResponse.delay }
-    }
-    .flatMap { $0 }
-    .sorted {
+    }.flatMap { $0 }.sorted {
       $0.serverResponse.offset < $1.serverResponse.offset
-  }
+    }
   
   return bestTimes.isEmpty ? nil : bestTimes[bestTimes.count / 2]
 }

--- a/Sources/NTPResponse.swift
+++ b/Sources/NTPResponse.swift
@@ -40,13 +40,16 @@ struct NTPResponse {
 }
 
 func bestTime(fromResponses times: [[FrozenNetworkTime]]) -> FrozenNetworkTime? {
-    let bestTimes = times.map { serverTimes in
-        serverTimes.min { $0.serverResponse.delay < $1.serverResponse.delay }
-    }.filter { $0 != nil }.flatMap { $0 }.sorted {
-        $0.serverResponse.offset < $1.serverResponse.offset
+  let bestTimes = times
+    .map { serverTimes -> FrozenNetworkTime? in
+      return serverTimes.min { $0.serverResponse.delay < $1.serverResponse.delay }
     }
-
-    return bestTimes.isEmpty ? nil : bestTimes[bestTimes.count / 2]
+    .flatMap { $0 }
+    .sorted {
+      $0.serverResponse.offset < $1.serverResponse.offset
+  }
+  
+  return bestTimes.isEmpty ? nil : bestTimes[bestTimes.count / 2]
 }
 
 private extension NTPResponse {


### PR DESCRIPTION
 Hi,

I've benchmarked the compiler performance on the app I'm working on (causing slow build times), and figured that the function that takes the most time is coming from TrueTime.

2957.60ms	/Users/mark/Dev/drops/Pods/TrueTime/Sources/NTPResponse.swift:42:6	func bestTime(fromResponses times: [[FrozenNetworkTime]]) -> FrozenNetworkTime?

https://medium.com/@RobertGummesson/regarding-swift-build-time-optimizations-fc92cdd91e31

This problem went away when an additional type annotation has been added to bestTime(fromResponses), and also removed unnecessary filter - flatMap {$0 }  does exactly the same thing.