### PR TITLE
Added minor minor additions/changes to lines 117-119 of NTPClient.swi…

### DIFF
--- a/Sources/NTPClient.swift
+++ b/Sources/NTPClient.swift
@@ -114,9 +114,9 @@ private extension NTPClient {
         if let referenceTime = referenceTime {
             let remainingInterval = max(0, config.pollInterval -
                                            referenceTime.underlyingValue.uptimeInterval)
-            timer = DispatchSource.makeTimerSource(flags: [], queue: queue)
-            timer?.setEventHandler(handler: invalidate)
+            timer = DispatchSource.makeTimerSource(flags: [], queue: queue) as? DispatchSource
             timer?.schedule(deadline: .now() + remainingInterval)
+            timer?.setEventHandler(handler: invalidate)
             timer?.resume()
         }
     }


### PR DESCRIPTION
…ft in the project which we initially made to fix the ability to update TrueTime on a regular interval.

All other changes we initially made to the code have already been implemented in the latest version of the project we pulled from the repository (such as: removing "let" from line 117 of NTPClient.swift; and changing line 62 of NTPExtensions.swift from "UInt64(time.tv_sec + secondsFrom1900To1970)" to UInt64(time.tv_sec) + UInt64(secondsFrom1900To1970)" to resolve an xCode warning).