### PR TITLE
Fix suspect crash cause in 5.0.0

### DIFF
--- a/Sources/NTPConnection.swift
+++ b/Sources/NTPConnection.swift
@@ -108,23 +108,18 @@ final class NTPConnection {
     func close(waitUntilFinished wait: Bool = false) {
         let work = {
             self.cancelTimer()
-            if let socket = self.socket, let source = self.source {
-                let disabledFlags = NTPConnection.callbackFlags |
-                                    kCFSocketAutomaticallyReenableDataCallBack |
-                                    kCFSocketAutomaticallyReenableReadCallBack |
-                                    kCFSocketAutomaticallyReenableWriteCallBack |
-                                    kCFSocketAutomaticallyReenableAcceptCallBack
-                CFSocketDisableCallBacks(socket, disabledFlags)
-                CFSocketInvalidate(socket)
-                CFRunLoopRemoveSource(CFRunLoopGetMain(), source, CFRunLoopMode.commonModes)
-                self.socket = nil
-                self.source = nil
-                self.debugLog("Connection closed \(self.address)")
-            }
-            if self.callbackPending {
-                Unmanaged.passUnretained(self).release()
-                self.callbackPending = false
-            }
+            guard let socket = self.socket, let source = self.source else { return }
+            let disabledFlags = NTPConnection.callbackFlags |
+                                kCFSocketAutomaticallyReenableDataCallBack |
+                                kCFSocketAutomaticallyReenableReadCallBack |
+                                kCFSocketAutomaticallyReenableWriteCallBack |
+                                kCFSocketAutomaticallyReenableAcceptCallBack
+            CFSocketDisableCallBacks(socket, disabledFlags)
+            CFSocketInvalidate(socket)
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), source, CFRunLoopMode.commonModes)
+            self.socket = nil
+            self.source = nil
+            self.debugLog("Connection closed \(self.address)")
         }
 
         if wait {
@@ -206,6 +201,10 @@ private extension NTPConnection {
             callbackQueue.async {
                 onComplete(self, result)
             }
+        }
+        if callbackPending {
+            callbackPending = false
+            Unmanaged.passUnretained(self).release()
         }
     }
 


### PR DESCRIPTION
### What did you change and why?
A change was introduced between 4.1.5 and 5.0.0 that is resulting in crashes. Multiple internal crash reports (as well as https://github.com/instacart/TrueTime.swift/issues/58) indicate an issue on         https://github.com/instacart/TrueTime.swift/blob/228bc5e44f09dcea617013f9c022efdbcc61c9d9/Sources/NTPConnection.swift#L67.

Internal reports indicated `EXC_BAD_ACCESS`. This would be expected to occur in `sync` block in case `self` is de-allocated. 

When comparing 4.1.5 to 5.0.0 (https://github.com/instacart/TrueTime.swift/compare/4.1.5...5.0.0#diff-77256cb830a28637414932596218ae34R125), relocated release of unmanaged self is suspect. 

This pr partially reverts https://github.com/instacart/TrueTime.swift/commit/c301ea833dcb1934590aa6772db0f396f1ab8f7d.

### Potential risks introduced?
Even more crashes?

### What tests were performed (include steps)?
Additional code was introduced to manually release NTPConnection object (similar to what was done prior to this change) and was able to repro the crash. It goes away after the changes in this pr. But more comprehensive testing might be needed.

### Checklist

- [ ] Unit/UI tests have been written (if necessary)
- [x] Manually tested