### PR TITLE
Stop importing CTrueTime as a separate module

### DIFF
--- a/Sources/Endian.swift
+++ b/Sources/Endian.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import CTrueTime
 
 protocol NetworkOrderConvertible {
     var byteSwapped: Self { get }

--- a/Sources/NTPClient.swift
+++ b/Sources/NTPClient.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2016 Instacart. All rights reserved.
 //
 
-import CTrueTime
-
 struct NTPConfig {
     let timeout: TimeInterval
     let maxRetries: Int

--- a/Sources/NTPConnection.swift
+++ b/Sources/NTPConnection.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2016 Instacart. All rights reserved.
 //
 
-import CTrueTime
 import Foundation
 
 typealias NTPConnectionCallback = (NTPConnection, FrozenNetworkTimeResult) -> Void

--- a/Sources/NTPExtensions.swift
+++ b/Sources/NTPExtensions.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import CTrueTime
 
 public extension timeval {
     static func uptime() -> timeval {

--- a/Sources/NTPResponse.swift
+++ b/Sources/NTPResponse.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2016 Instacart. All rights reserved.
 //
 
-import CTrueTime
 import Foundation
 
 struct NTPResponse {

--- a/Sources/ReferenceTime.swift
+++ b/Sources/ReferenceTime.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2016 Instacart. All rights reserved.
 //
 
-import CTrueTime
-
 typealias FrozenTimeResult = Result<FrozenTime, NSError>
 typealias FrozenTimeCallback = (FrozenTimeResult) -> Void
 

--- a/Sources/TrueTime.h
+++ b/Sources/TrueTime.h
@@ -7,6 +7,7 @@
 //
 
 @import Foundation;
+#import "ntp_types.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/TrueTime.swift
+++ b/Sources/TrueTime.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2016 Instacart. All rights reserved.
 //
 
-import CTrueTime
 import Foundation
 
 @objc public enum TrueTimeError: Int {

--- a/Tests/ArbitraryExtensions.swift
+++ b/Tests/ArbitraryExtensions.swift
@@ -7,7 +7,6 @@
 //
 
 @testable import TrueTime
-import CTrueTime
 import SwiftCheck
 
 extension timeval: Arbitrary {

--- a/Tests/NTPExtensionsSpec.swift
+++ b/Tests/NTPExtensionsSpec.swift
@@ -7,7 +7,6 @@
 //
 
 @testable import TrueTime
-import CTrueTime
 import Nimble
 import Quick
 import SwiftCheck

--- a/TrueTime.podspec
+++ b/TrueTime.podspec
@@ -14,8 +14,6 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '9.0'
 
-  s.source_files = 'Sources/*.{swift,h,m}', 'Sources/CTrueTime/*.h'
-  s.public_header_files = 'Sources/*.h'
-  s.pod_target_xcconfig = { 'SWIFT_INCLUDE_PATHS' => '$(SRCROOT)/TrueTime/Sources/CTrueTime/**' }
-  s.preserve_paths  = 'Sources/CTrueTime/module.modulemap'
+  s.source_files = 'Sources/**/*.{swift,h,m}'
+  s.public_header_files = 'Sources/**/*.h'
 end

--- a/TrueTime.xcodeproj/project.pbxproj
+++ b/TrueTime.xcodeproj/project.pbxproj
@@ -77,6 +77,9 @@
 		28EBCA011DC2CE6900CE788E /* GCDLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28EBC9FF1DC2CE6900CE788E /* GCDLock.swift */; };
 		28EBCA021DC2CE6900CE788E /* GCDLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28EBC9FF1DC2CE6900CE788E /* GCDLock.swift */; };
 		28F30A3F1DC1374D00CCF4F0 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28F30A3D1DC1374700CCF4F0 /* ViewController.swift */; };
+		D4C54EC523D1131A009DE762 /* ntp_types.h in Headers */ = {isa = PBXBuildFile; fileRef = D4C54EC323D1131A009DE762 /* ntp_types.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D4C54EC623D1195D009DE762 /* ntp_types.h in Headers */ = {isa = PBXBuildFile; fileRef = D4C54EC323D1131A009DE762 /* ntp_types.h */; };
+		D4C54EC723D1195E009DE762 /* ntp_types.h in Headers */ = {isa = PBXBuildFile; fileRef = D4C54EC323D1131A009DE762 /* ntp_types.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -191,6 +194,8 @@
 		28BD083F1D6248EC00D9981C /* TrueTime.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TrueTime.m; sourceTree = "<group>"; };
 		28EBC9FF1DC2CE6900CE788E /* GCDLock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GCDLock.swift; sourceTree = "<group>"; };
 		28F30A3D1DC1374700CCF4F0 /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		D4C54EC323D1131A009DE762 /* ntp_types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ntp_types.h; sourceTree = "<group>"; };
+		D4C54EC423D1131A009DE762 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -262,6 +267,7 @@
 		2800905D1D45489D004C788E /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				D4C54EC223D1131A009DE762 /* CTrueTime */,
 				280090611D45489D004C788E /* TrueTime.swift */,
 				2866628D1D5B771D002CA06B /* HostResolver.swift */,
 				288334BF1DAF200000A38C7C /* NTPClient.swift */,
@@ -468,6 +474,15 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		D4C54EC223D1131A009DE762 /* CTrueTime */ = {
+			isa = PBXGroup;
+			children = (
+				D4C54EC323D1131A009DE762 /* ntp_types.h */,
+				D4C54EC423D1131A009DE762 /* module.modulemap */,
+			);
+			path = CTrueTime;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -476,6 +491,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				280090721D45489D004C788E /* TrueTime.h in Headers */,
+				D4C54EC523D1131A009DE762 /* ntp_types.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -484,6 +500,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				285047ED1D4D681300DE4CE8 /* TrueTime.h in Headers */,
+				D4C54EC723D1195E009DE762 /* ntp_types.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -492,6 +509,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				280090731D45489D004C788E /* TrueTime.h in Headers */,
+				D4C54EC623D1195D009DE762 /* ntp_types.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1108,7 +1126,7 @@
 				PRODUCT_NAME = TrueTime;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_INCLUDE_PATHS = "$(SRCROOT) $(SRCROOT)/Sources/CTrueTime";
+				SWIFT_INCLUDE_PATHS = "$(SRCROOT)";
 				SWIFT_INSTALL_OBJC_HEADER = YES;
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(SWIFT_MODULE_NAME)-Swift.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -1137,7 +1155,7 @@
 				PRODUCT_NAME = TrueTime;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_INCLUDE_PATHS = "$(SRCROOT) $(SRCROOT)/Sources/CTrueTime";
+				SWIFT_INCLUDE_PATHS = "$(SRCROOT)";
 				SWIFT_INSTALL_OBJC_HEADER = YES;
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(SWIFT_MODULE_NAME)-Swift.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";


### PR DESCRIPTION
### What did you change and why?

Stop importing `CTrueTime` as a separate module. This fixes https://github.com/instacart/TrueTime.swift/issues/57.

### Potential risks introduced?

Adding support for SPM in the future will be harder as we can't have a mixed language target. However, since we don't support it currently, I think it's a worth tradeoff to fix Carthage builds.

### What tests were performed (include steps)?

- Run `pod lib lint` to validate CocoaPods integration
- Integrated `TrueTime.swift` in a project that uses https://github.com/Wolox/carthage_cache

### Checklist

- [ ] Unit/UI tests have been written (if necessary)
- [ ] Manually tested
