### PR TITLE
Kotlin Multiplatform CocoaPods dependency support

### DIFF
--- a/Sources/TrueTime.h
+++ b/Sources/TrueTime.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Instacart. All rights reserved.
 //
 
-@import Foundation;
+#import "Foundation/Foundation.h"
 #import "ntp_types.h"
 
 NS_ASSUME_NONNULL_BEGIN


### PR DESCRIPTION
### What did you change and why?
@import declaration breaks using TrueTime as CocoaPods dependency in Kotlin Multiplatform because modules are disabled. #import declaration fixes this issue

### Potential risks introduced?
Nothing risks  see

### What tests were performed (include steps)?
Work on real iOS app inside Kotlin Multiplatform library

### Checklist

- [ ] Unit/UI tests have been written (if necessary)
- [ ] Manually tested
