### PR TITLE
Update TrueTime.podspec

### DIFF
--- a/TrueTime.podspec
+++ b/TrueTime.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.swift_version = '5.0'
 
   s.requires_arc = true
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '11.0'
   s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '9.0'
 


### PR DESCRIPTION
Latest XCode requires iOS 11.0 as minimum target

### What did you change and why?
I am building on latest XCode, carthage fails as minimum ios target is set to 8.0

### Potential risks introduced?


### What tests were performed (include steps)?


### Checklist

- [ ] Unit/UI tests have been written (if necessary)
- [ ] Manually tested
