### PR TITLE
Added isStarted property to TrueTimeClient and NTPClient.

### DIFF
--- a/Sources/NTPClient.swift
+++ b/Sources/NTPClient.swift
@@ -92,6 +92,7 @@ final class NTPClient {
     private var pool: [String] = [] {
         didSet { invalidate() }
     }
+    var isStarted: Bool { return self.reachability.callback != nil }
 }
 
 private extension NTPClient {

--- a/Sources/TrueTime.swift
+++ b/Sources/TrueTime.swift
@@ -92,6 +92,7 @@ public typealias LogCallback = (String) -> Void
     @objc public var maxConnections: Int { return config.maxConnections }
     @objc public var maxServers: Int { return config.maxServers}
     @objc public var numberOfSamples: Int { return config.numberOfSamples}
+    @objc public var isStarted: Bool { return ntp.isStarted }
 
     private let config: NTPConfig
     private let ntp: NTPClient


### PR DESCRIPTION
### What did you change and why?
Added isStarted property to TrueTimeClient and NTPClient.
If start() is called occasionally twice,  app crashes on check : 
```swift
precondition(self.reachability.callback == nil, "Already started")
```
We can avoid this crash calling start() like that:
```swift
let client = TrueTimeClient.sharedInstance
if (!client.isStarted) {
    client.start(pool: [NTP_HOST], port: NTP_PORT)
}
```

### Potential risks introduced?
No new risks.

### What tests were performed (include steps)?
Manual tests. 

### Checklist

- [ ] Unit/UI tests have been written (if necessary)
- [X] Manually tested
